### PR TITLE
Fix TypeError: Use Class Method for `load_from_checkpoint` (lightning 2.1.1 onwards)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,6 +127,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+.micromamba
 
 # Spyder project settings
 .spyderproject

--- a/pl_crossvalidate/ensemble.py
+++ b/pl_crossvalidate/ensemble.py
@@ -30,8 +30,7 @@ class EnsembleLightningModule(LightningModule):
 
     def __init__(self, model: LightningModule, ckpt_paths: List[str]) -> None:
         super().__init__()
-        model_cls = type(model)
-        self.models = nn.ModuleList([model_cls.load_from_checkpoint(p) for p in ckpt_paths])
+        self.models = nn.ModuleList([type(model).load_from_checkpoint(p) for p in ckpt_paths])
 
         # We need to set the trainer to something to avoid errors
         model._trainer = object()

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -30,7 +30,7 @@ def test_trainer_initialization(arguments, expected):
 @pytest.mark.parametrize("accelerator", ["cpu", "gpu"])
 def test_cross_validate(tmp_path, accelerator):
     """Test cross validation finish a basic run."""
-    if not torch.cuda.is_available() and torch.cuda.device_count() < 1:
+    if accelerator == "gpu" and not torch.cuda.is_available() and torch.cuda.device_count() < 1:
         pytest.skip("test requires cuda support")
 
     model = BoringModel()


### PR DESCRIPTION
  - **Issue Summary:** This pull request addresses a `TypeError` encountered when calling `load_from_checkpoint` from an instance of a `LightningModule` since the update to lightning 2.1.1. 
  - **Technical Details:** As outlined in the [_restricted_classmethod](https://github.com/Lightning-AI/pytorch-lightning/blob/7fee4ae3a6b9f6c763e590c179fcb6b6a40c5e10/src/lightning/pytorch/utilities/model_helpers.py#L107) and [load_from_checkpoint](https://github.com/Lightning-AI/pytorch-lightning/blob/7fee4ae3a6b9f6c763e590c179fcb6b6a40c5e10/src/lightning/pytorch/core/module.py#L1481) implementations, the `load_from_checkpoint` method must now be called from the class directly.
  - **Encountered Issue:** Additionally, a potential bug involving `inspect.getmembers(model)` triggering `_restricted_class_method` in `EnsembleLightningModule` was identified. This may require further investigation to determine if it necessitates a workaround or a separate issue to be raised with the lightning team.
  - **Action Requested:** Feedback and insights on the `_restricted_class_method` issue and the overall changes are highly appreciated.